### PR TITLE
Fix turnstile gating

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -10,6 +10,7 @@ import { StorageService } from './services/storage';
 import { TagService } from './services/tag';
 import { UserService } from './services/user';
 import { ConfigService } from './services/config';
+import { TurnstileService } from './services/turnstile';
 
 export const app = () => new Elysia({ aot: false })
     .use(cors({
@@ -35,6 +36,7 @@ export const app = () => new Elysia({ aot: false })
     .use(FriendService())
     .use(SEOService())
     .use(RSSService())
+    .use(TurnstileService())
     .use(ConfigService())
     .get('/', () => `Hi`)
     .onError(({ path, params, code }) => {

--- a/server/src/services/turnstile.ts
+++ b/server/src/services/turnstile.ts
@@ -1,0 +1,37 @@
+import Elysia, { t } from 'elysia';
+import { verifyTurnstile } from '../utils/turnstile';
+import { getEnv } from '../utils/di';
+
+export function TurnstileService() {
+    const env = getEnv();
+    return new Elysia({ aot: false })
+        .group('/turnstile', (app) =>
+            app.post('/verify', async ({ cookie, body: { token }, set }) => {
+                const pass = await verifyTurnstile(token);
+                if (!pass) {
+                    set.status = 400;
+                    return 'Turnstile verification failed';
+                }
+                try {
+                    const url = new URL(env.FRONTEND_URL);
+                    const parts = url.hostname.split('.');
+                    const domain = parts.slice(-2).join('.');
+                    cookie['turnstile_verified'].set({
+                        value: 'true',
+                        path: '/',
+                        domain: '.' + domain,
+                        expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365),
+                    });
+                } catch {
+                    cookie['turnstile_verified'].set({
+                        value: 'true',
+                        path: '/',
+                        expires: new Date(Date.now() + 1000 * 60 * 60 * 24 * 365),
+                    });
+                }
+                return 'OK';
+            }, {
+                body: t.Object({ token: t.String() })
+            })
+        );
+}


### PR DESCRIPTION
## Summary
- add a `TurnstileService` to verify tokens and set a cookie across subdomains
- gate the UI behind a turnstile challenge until verified

## Testing
- `npm run check`
- `npm run t`

------
https://chatgpt.com/codex/tasks/task_b_68496972fc288332be964582a19cf9d2